### PR TITLE
feat: pytest config via pyproject

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,10 +15,6 @@
   },
   "editor.formatOnSave": true,
   "python.defaultInterpreterPath": ".venv/bin/python",
-  "python.testing.pytestArgs": [
-    "--disable-warnings",
-    "tests"
-  ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "[python]": {

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ format:
 	ruff format
 
 test:
-	pytest --disable-warnings -x -n auto --cov-report= --cov=$(SOURCEPATH) tests/
+	pytest -n auto --cov-report= --cov=fastapi_extras/
 
 coverage: test .coverage
 	coverage report -m --fail-under=100

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ format:
 	ruff format
 
 test:
-	pytest -n auto --cov-report= --cov=fastapi_extras/
+	pytest -n auto --cov-report= --cov=$(SOURCEPATH)
 
 coverage: test .coverage
 	coverage report -m --fail-under=100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,7 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.pytest.ini_options]
+addopts = "--disable-warnings -x"
+testpaths = ["tests/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fastapi-ext-pkg"
-version = "0.3.0"
+version = "0.4.0"
 description = "A well-tailored utility set for FastAPI."
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [


### PR DESCRIPTION
### Contain
- [x] New feature

### Details
* Update `pyproject.toml` adding basic/default configurations for Pytest.
* Update `Makefile` and `.vscode/settings.json` removing default arguments for Pytest (now they are read from pyproject.toml).
